### PR TITLE
Fix issue when not being leader

### DIFF
--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -597,8 +597,8 @@ class BaseFinosLegendCharm(charm.CharmBase):
         # to allow for the `_refresh_charm_status` method do determine
         # if all the relations are present and write the configs itself:
         # container.autostart()
-
-        self._update_gitlab_relation_callback_uris()
+        if self.unit.is_leader():
+            self._update_gitlab_relation_callback_uris()
         self._refresh_charm_status()
 
 
@@ -746,6 +746,9 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
             legend_db_credentials, legend_gitlab_credentials)
 
     def _update_gitlab_relation_callback_uris(self):
+        if not self.unit.is_leader():
+            # We're not the leader, so nothing to do.
+            return
         relation = self._get_relation(self._get_legend_gitlab_relation_name())
         if not relation:
             return
@@ -777,9 +780,7 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
 
     def _on_legend_gitlab_relation_joined(
             self, event: charm.RelationJoinedEvent) -> None:
-        redirect_uris = self._get_legend_gitlab_redirect_uris()
-        legend_gitlab.set_legend_gitlab_redirect_uris_in_relation_data(
-            event.relation.data[self.app], redirect_uris)
+        self._update_gitlab_relation_callback_uris()
 
     def _on_legend_gitlab_relation_changed(
             self, _: charm.RelationChangedEvent) -> None:

--- a/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
@@ -384,6 +384,47 @@ class BaseFinosLegendCharmTestCase(unittest.TestCase):
 
     @mock.patch("ops.testing._TestingPebbleClient.restart_services")
     @mock.patch("ops.testing._TestingPebbleClient.stop_services")
+    def _test_update_config_gitlab_relation_without_being_leader(self, _container_stop_mock, _container_restart_mock):
+        self.harness.begin_with_initial_hooks()
+
+        # Setup the URI getter mock,
+        mock_get_uris = self.patch(self.harness.charm, '_get_legend_gitlab_redirect_uris')
+        fake_callback_uris = ['legendary.callback.url']
+        mock_get_uris.return_value = fake_callback_uris
+
+        # Add the gitlab integrator relation and grab its relation ID.
+        test_data = self.harness.charm._get_relations_test_data()
+        gitlab_rel_name = self.harness.charm._get_legend_gitlab_relation_name()
+        gitlab_rel_data = test_data.pop(gitlab_rel_name)
+        gitlab_rel_id = self._add_relation(gitlab_rel_name, gitlab_rel_data)
+
+        # Add the rest of the necessary relations.
+        for rel_name, rel_data in test_data.items():
+            self._add_relation(rel_name, rel_data)
+            self.harness.update_config()
+
+        # Assert that the unit is currently active.
+        self.assertIsInstance(
+            self.harness.charm.unit.status, model.ActiveStatus)
+
+        # Assert that the initial Callback URIs have been set.
+        relation_data = self.harness.get_relation_data(gitlab_rel_id, self.harness.charm.app)
+        expected_rel_data = {'legend-gitlab-redirect-uris': json.dumps(fake_callback_uris)}
+        self.assertNotEqual(expected_rel_data, relation_data)
+
+        # Setup for the config update.
+        fake_callback_uris = ['foo.lish']
+        mock_get_uris.return_value = fake_callback_uris
+
+        # Update the external-hostname config option and assert that the relation data changed.
+        self.harness.update_config({"external-hostname": "foo.lish"})
+
+        relation_data = self.harness.get_relation_data(gitlab_rel_id, self.harness.charm.app)
+        expected_rel_data = {'legend-gitlab-redirect-uris': json.dumps(fake_callback_uris)}
+        self.assertNotEqual(expected_rel_data, relation_data)
+
+    @mock.patch("ops.testing._TestingPebbleClient.restart_services")
+    @mock.patch("ops.testing._TestingPebbleClient.stop_services")
     def _test_upgrade_charm(self, _container_stop_mock, _container_restart_mock):
         self.harness.set_leader()
         self.harness.begin_with_initial_hooks()

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -101,6 +101,9 @@ class LegendSdlcTestCase(legend_operator_testing.TestBaseFinosCoreServiceLegendC
     def test_config_changed_update_gitlab_relation(self):
         self._test_update_config_gitlab_relation()
 
+    def test_update_config_gitlab_relation_without_being_leader(self):
+        self._test_update_config_gitlab_relation_without_being_leader()
+
     def test_config_changed_update_studio_relation(self):
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()


### PR DESCRIPTION
Fixes an issue when not being leader and getting an error, trying to update the gitlab relation callback uris.